### PR TITLE
Change std::shared_ptr to typedefs provided by urdfdom. 

### DIFF
--- a/src/Joint.cpp
+++ b/src/Joint.cpp
@@ -21,7 +21,7 @@ smurf::Joint::Joint(const std::string &name, smurf::Frame* sourceFrame, smurf::F
 smurf::Joint::Joint(const std::string &name, smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, 
                     const std::string& port, const std::string& driverName, base::JointLimitRange& limits, 
                     const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin,
-                    std::shared_ptr<urdf::Joint> jointModel): 
+                    urdf::JointSharedPtr jointModel):
                     DynamicTransformation(name, sourceFrame, targetFrame, provider, port), limits(limits), 
                     sourceToAxis(sourceToAxis), parentToJointOrigin(parentToJointOrigin),
                     jointModel(jointModel)
@@ -51,7 +51,7 @@ smurf::Joint::Joint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const 
 smurf::Joint::Joint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, 
                     const std::string& port, const std::string& driverName, base::JointLimitRange& limits, 
                     const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin,
-                    std::shared_ptr<urdf::Joint> jointModel): 
+                    urdf::JointSharedPtr jointModel):
                     DynamicTransformation(sourceFrame, targetFrame, provider, port), limits(limits), 
                     sourceToAxis(sourceToAxis), parentToJointOrigin(parentToJointOrigin),
                     jointModel(jointModel)
@@ -68,7 +68,7 @@ const Eigen::Affine3d& smurf::Joint::getParentToJointOrigin() const
     return this -> parentToJointOrigin;
 };
 
-std::shared_ptr<urdf::Joint> smurf::Joint::getJointModel() const
+urdf::JointSharedPtr smurf::Joint::getJointModel() const
 {
     return this -> jointModel;
 };

--- a/src/Joint.hpp
+++ b/src/Joint.hpp
@@ -18,13 +18,13 @@ namespace smurf{
         
         Joint(const std::string &name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin); 
         
-        Joint(const std::string &name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel); 
+        Joint(const std::string &name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
         
         Joint(Frame* sourceFrame, Frame* targetFrame, const std::string &provider, const std::string &port, const std::string &driverName, base::JointLimitRange &limits, const Eigen::Affine3d &sourceToAxis);
         
         Joint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin); 
         
-        Joint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel); 
+        Joint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
 
         const Eigen::Affine3d &getSourceToAxis() const;
         
@@ -32,7 +32,7 @@ namespace smurf{
         
         void setParentToJointOrigin(const Eigen::Affine3d inParentToJointOrigin);
         
-        std::shared_ptr<urdf::Joint> getJointModel() const;
+        urdf::JointSharedPtr getJointModel() const;
         
         
         
@@ -63,7 +63,7 @@ namespace smurf{
          * Urdf data of the joint
          * 
          */
-        std::shared_ptr<urdf::Joint> jointModel;
+        urdf::JointSharedPtr jointModel;
         
     };
     

--- a/src/Robot.cpp
+++ b/src/Robot.cpp
@@ -78,10 +78,10 @@ void smurf::Robot::loadCollidables()
 {
 
     if (debug) {LOG_DEBUG_S << "[smurf::Robot::loadCollidables] Loading collidables just started ";}
-    for(std::pair<std::string, std::shared_ptr<urdf::Link>> link: model->links_)
+    for(std::pair<std::string, urdf::LinkSharedPtr> link: model->links_)
     {
         smurf::Frame* frame = getFrameByName(link.first);
-        for(std::shared_ptr<urdf::Collision> collision : link.second->collision_array)
+        for(urdf::CollisionSharedPtr collision : link.second->collision_array)
         {
             // Find the correspondent collidable data if exists and create the collidable object
             smurf::Collidable* collidable = new Collidable(collision->name, getContactParams(collision->name, link.first), *collision );
@@ -92,10 +92,10 @@ void smurf::Robot::loadCollidables()
 
 void smurf::Robot::loadCollisions()
 {
-    for(std::pair<std::string, std::shared_ptr<urdf::Link>> link: model->links_)
+    for(std::pair<std::string, urdf::LinkSharedPtr> link: model->links_)
     {
         smurf::Frame* frame = getFrameByName(link.first);
-        for(std::shared_ptr<urdf::Collision> collision : link.second->collision_array)
+        for(urdf::CollisionSharedPtr collision : link.second->collision_array)
         {
             frame->addCollision(*collision);
         }
@@ -104,7 +104,7 @@ void smurf::Robot::loadCollisions()
 
 void smurf::Robot::loadInertials()
 {
-    for(std::pair<std::string, std::shared_ptr<urdf::Link>> link: model->links_)
+    for(std::pair<std::string, urdf::LinkSharedPtr> link: model->links_)
     {
         smurf::Frame* frame = getFrameByName(link.first);
         if (debug) { LOG_DEBUG_S << " [smurf::Robot::loadInertials] Checking for inertials in link with name " << link.first;}
@@ -117,7 +117,7 @@ void smurf::Robot::loadInertials()
     }
 }
 
-configmaps::ConfigMap smurf::Robot::getAnnotations(const std::shared_ptr<urdf::Joint>& joint)
+configmaps::ConfigMap smurf::Robot::getAnnotations(const urdf::JointSharedPtr& joint)
 {
     bool foundAnnotation = false;
     configmaps::ConfigMap annotations;
@@ -139,9 +139,9 @@ configmaps::ConfigMap smurf::Robot::getAnnotations(const std::shared_ptr<urdf::J
 
 void smurf::Robot::loadJoints()
 {
-    for(std::pair<std::string, std::shared_ptr<urdf::Joint> > jointIt: model->joints_)
+    for(std::pair<std::string, urdf::JointSharedPtr > jointIt: model->joints_)
     {
-        std::shared_ptr<urdf::Joint> joint = jointIt.second;
+        urdf::JointSharedPtr joint = jointIt.second;
         Frame *source = getFrameByName(joint->parent_link_name);
         Frame *target = getFrameByName(joint->child_link_name);
         switch(joint->type)
@@ -253,11 +253,11 @@ void smurf::Robot::loadSensors()
     
 }
 
-void smurf::Robot::loadFrames(std::shared_ptr< urdf::ModelInterface > model)
+void smurf::Robot::loadFrames(urdf::ModelInterfaceSharedPtr model)
 {
-    std::shared_ptr<const urdf::Link> root = model->getRoot();
+    urdf::LinkConstSharedPtr root = model->getRoot();
     const std::string rootName = root->name;
-    for(std::pair<std::string, std::shared_ptr<urdf::Link>> link: model->links_)
+    for(std::pair<std::string, urdf::LinkSharedPtr> link: model->links_)
     {
         Frame *frame = new Frame(link.first);
         availableFrames.push_back(frame);
@@ -271,10 +271,10 @@ void smurf::Robot::loadFrames(std::shared_ptr< urdf::ModelInterface > model)
 
 void smurf::Robot::loadVisuals()
 {
-    for(std::pair<std::string, std::shared_ptr<urdf::Link>> link: model->links_)
+    for(std::pair<std::string, urdf::LinkSharedPtr> link: model->links_)
     {
         Frame *frame = getFrameByName(link.second->name);
-        for(std::shared_ptr<urdf::Visual> visual : link.second->visual_array)
+        for(urdf::VisualSharedPtr visual : link.second->visual_array)
         {
             frame->addVisual(*visual);
         }

--- a/src/Robot.hpp
+++ b/src/Robot.hpp
@@ -7,6 +7,7 @@
 #include "Sensor.hpp"
 #include "Motor.hpp"
 #include <configmaps/ConfigData.h>
+#include <urdf_world/types.h>
 
 #include <mars/interfaces/contact_params.h>
 
@@ -98,7 +99,7 @@ namespace smurf
         
         void loadVisuals();
 
-        void loadFrames(std::shared_ptr< urdf::ModelInterface > model);
+        void loadFrames(urdf::ModelInterfaceSharedPtr model);
         
         /**
          * Loads all the information from the Smurf model in the Robot 
@@ -116,10 +117,10 @@ namespace smurf
         
         Frame *getFrameByName(const std::string &name);
 
-        configmaps::ConfigMap getAnnotations(const std::shared_ptr<urdf::Joint> &joint);
+        configmaps::ConfigMap getAnnotations(const urdf::JointSharedPtr &joint);
         
         Frame *rootFrame;
-        std::shared_ptr<urdf::ModelInterface> model;
+        urdf::ModelInterfaceSharedPtr model;
         configmaps::ConfigMap *smurfMap;
         
         std::vector<smurf::Frame *> availableFrames;

--- a/src/RotationalJoint.cpp
+++ b/src/RotationalJoint.cpp
@@ -11,7 +11,7 @@ smurf::RotationalJoint::RotationalJoint(const std::string name, smurf::Frame* so
                                         const std::string& provider, const std::string& port, 
                                         const std::string& driverName, base::JointLimitRange& limits, 
                                         const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, 
-                                        const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel): 
+                                        const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel):
                                         Joint(name, sourceFrame, targetFrame, provider, port, driverName, limits, sourceToAxis, parentToJointOrigin, jointModel), 
                                         rotationAxis(rotationAxis){}
 
@@ -26,6 +26,6 @@ smurf::RotationalJoint::RotationalJoint(smurf::Frame* sourceFrame, smurf::Frame*
                                         const std::string& provider, const std::string& port, 
                                         const std::string& driverName, base::JointLimitRange& limits, 
                                         const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, 
-                                        const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel): 
+                                        const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel):
                                         Joint(sourceFrame, targetFrame, provider, port, driverName, limits, sourceToAxis, parentToJointOrigin, jointModel), 
                                         rotationAxis(rotationAxis){}

--- a/src/RotationalJoint.hpp
+++ b/src/RotationalJoint.hpp
@@ -11,11 +11,11 @@ namespace smurf
     public:
         RotationalJoint(const std::string name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis,  const Eigen::Vector3d &rotationAxis);
         
-        RotationalJoint(const std::string name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel); 
+        RotationalJoint(const std::string name, Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
         
         RotationalJoint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis,  const Eigen::Vector3d &rotationAxis);
         
-        RotationalJoint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel); 
+        RotationalJoint(Frame* sourceFrame, Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& rotationAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
         /**
          * Rotation axis of the joint in the target frame.
          * */

--- a/src/TranslationalJoint.cpp
+++ b/src/TranslationalJoint.cpp
@@ -9,7 +9,7 @@ smurf::TranslationalJoint::TranslationalJoint(const std::string &name, smurf::Fr
 smurf::TranslationalJoint::TranslationalJoint(const std::string &name, smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, 
                                               const std::string& port, const std::string& driverName, base::JointLimitRange& limits, 
                                               const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, 
-                                              const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel): 
+                                              const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel):
                                               Joint(name, sourceFrame, targetFrame, provider, port, driverName, limits, sourceToAxis, parentToJointOrigin, jointModel), 
                                               translationAxis(translationAxis)
                                               {}
@@ -23,7 +23,7 @@ smurf::TranslationalJoint::TranslationalJoint(smurf::Frame* sourceFrame, smurf::
 smurf::TranslationalJoint::TranslationalJoint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, 
                                               const std::string& port, const std::string& driverName, base::JointLimitRange& limits, 
                                               const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, 
-                                              const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel): 
+                                              const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel):
                                               Joint(sourceFrame, targetFrame, provider, port, driverName, limits, sourceToAxis, parentToJointOrigin, jointModel), 
                                               translationAxis(translationAxis)
                                               {}

--- a/src/TranslationalJoint.hpp
+++ b/src/TranslationalJoint.hpp
@@ -10,11 +10,11 @@ namespace smurf{
     public:
         TranslationalJoint(const std::string &name, smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d &translationAxis);
         
-        TranslationalJoint(const std::string &name, smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel);
+        TranslationalJoint(const std::string &name, smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
         
         TranslationalJoint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d &translationAxis);
         
-        TranslationalJoint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, const Eigen::Affine3d& parentToJointOrigin, std::shared_ptr<urdf::Joint> jointModel);
+        TranslationalJoint(smurf::Frame* sourceFrame, smurf::Frame* targetFrame, const std::string& provider, const std::string& port, const std::string& driverName, base::JointLimitRange& limits, const Eigen::Affine3d& sourceToAxis, const Eigen::Vector3d& translationAxis, const Eigen::Affine3d& parentToJointOrigin, urdf::JointSharedPtr jointModel);
         
         /**
          * Sliding axis of the joint in the target frame.


### PR DESCRIPTION
This ensures backwards compatibility with older urdfdom versions
